### PR TITLE
Handle register field values specified in hex

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -420,7 +420,7 @@ pub fn main() anyerror!void {
                 } else if (ascii.eqlIgnoreCase(chunk.tag, "value")) {
                     var cur_enum = &cur_field.enum_fields.items[cur_field.enum_fields.items.len - 1];
                     if (chunk.data) |data| {
-                        cur_enum.value = try fmt.parseInt(u32, data, 10);
+                        cur_enum.value = try fmt.parseInt(u32, data, 0);
                     }
                 }
             },


### PR DESCRIPTION
Failed to parse the following file because the field value is specified in hex. This fixes that by letting parseInt auto detect the value's base.

https://raw.githubusercontent.com/cmsis-svd/cmsis-svd-data/refs/heads/main/data/STMicro/STM32G491xx.svd

![Screenshot from 2024-11-11 09-09-05](https://github.com/user-attachments/assets/b032fe38-d05c-4aa8-81f8-c8fc6a25f5ad)
